### PR TITLE
Option to add/remove AppMenu

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -785,6 +785,50 @@
                   </object>
                 </child>
                 <child>
+                  <object class="GtkListBoxRow" id="show_appmenu_row">
+                    <property name="width_request">100</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="show_appmenu_grid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkSwitch" id="show_appmenu_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="show_appmenu_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Show AppMenu</property>
+                            <property name="use_markup">True</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
                   <object class="GtkListBoxRow" id="show_window_previews">
                     <property name="width_request">100</property>
                     <property name="visible">True</property>

--- a/panel.js
+++ b/panel.js
@@ -94,6 +94,7 @@ const dtpPanel = new Lang.Class({
 
         this._panelConnectId = this.panel.actor.connect('allocate', Lang.bind(this, function(actor,box,flags){this._allocate(actor,box,flags);}));
         this.container.remove_child(this.appMenu.container);
+        this.panel._rightBox.insert_child_at_index(this.appMenu.container, 0);
         this.taskbar = new Taskbar.taskbar(this._dtpSettings);
         Main.overview.dashIconSize = this.taskbar.iconSize;
 
@@ -103,6 +104,7 @@ const dtpPanel = new Lang.Class({
         this._oldCenterBoxStyle = this.panel._centerBox.get_style();
         this._oldRightBoxStyle = this.panel._rightBox.get_style();
         this._setActivitiesButtonVisible(this._dtpSettings.get_boolean('show-activities-button'));
+        this._setAppmenuVisible(this._dtpSettings.get_boolean('show-appmenu'));
         this._setClockLocation(this._dtpSettings.get_string('location-clock'));
         
         this.panel.actor.add_style_class_name('dashtopanelMainPanel');
@@ -165,6 +167,8 @@ const dtpPanel = new Lang.Class({
 
         this._signalsHandler.destroy();
         this.container.remove_child(this.taskbar.actor);
+        this._setAppmenuVisible(true);
+        this.panel._rightBox.remove_child(this.appMenu.container);
         this.container.add_child(this.appMenu.container);
         this.taskbar.destroy();
         this.panel.actor.disconnect(this._panelConnectId);
@@ -209,6 +213,10 @@ const dtpPanel = new Lang.Class({
 
         this._dtpSettings.connect('changed::show-activities-button', Lang.bind(this, function() {
             this._setActivitiesButtonVisible(this._dtpSettings.get_boolean('show-activities-button'));
+        }));
+        
+        this._dtpSettings.connect('changed::show-appmenu', Lang.bind(this, function() {
+            this._setAppmenuVisible(this._dtpSettings.get_boolean('show-appmenu'));
         }));
 
         this._dtpSettings.connect('changed::location-clock', Lang.bind(this, function() {
@@ -318,6 +326,12 @@ const dtpPanel = new Lang.Class({
         if(this.panel.statusArea.activities)
             isVisible ? this.panel.statusArea.activities.actor.show() :
                 this.panel.statusArea.activities.actor.hide();
+    },
+    
+    _setAppmenuVisible: function(isVisible) {
+        if(this.appMenu)
+            isVisible ? this.appMenu.actor.show() :
+                this.appMenu.actor.hide();
     },
 
     _setClockLocation: function(loc) {

--- a/panel.js
+++ b/panel.js
@@ -94,7 +94,6 @@ const dtpPanel = new Lang.Class({
 
         this._panelConnectId = this.panel.actor.connect('allocate', Lang.bind(this, function(actor,box,flags){this._allocate(actor,box,flags);}));
         this.container.remove_child(this.appMenu.container);
-        this.panel._rightBox.insert_child_at_index(this.appMenu.container, 0);
         this.taskbar = new Taskbar.taskbar(this._dtpSettings);
         Main.overview.dashIconSize = this.taskbar.iconSize;
 
@@ -167,8 +166,7 @@ const dtpPanel = new Lang.Class({
 
         this._signalsHandler.destroy();
         this.container.remove_child(this.taskbar.actor);
-        this._setAppmenuVisible(true);
-        this.panel._rightBox.remove_child(this.appMenu.container);
+        this._setAppmenuVisible(false);
         this.container.add_child(this.appMenu.container);
         this.taskbar.destroy();
         this.panel.actor.disconnect(this._panelConnectId);
@@ -329,9 +327,12 @@ const dtpPanel = new Lang.Class({
     },
     
     _setAppmenuVisible: function(isVisible) {
-        if(this.appMenu)
-            isVisible ? this.appMenu.actor.show() :
-                this.appMenu.actor.hide();
+        let centerBox = this.panel._centerBox;
+        if (isVisible && centerBox.get_children().indexOf(this.appMenu.container) == -1) {
+            centerBox.insert_child_at_index(this.appMenu.container, 0)
+        } else if (!isVisible && centerBox.get_children().indexOf(this.appMenu.container) != -1) {
+            centerBox.remove_child(this.appMenu.container);
+        }
     },
 
     _setClockLocation: function(loc) {

--- a/prefs.js
+++ b/prefs.js
@@ -147,6 +147,10 @@ const Settings = new Lang.Class({
                             this._builder.get_object('show_activities_button_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-appmenu',
+                            this._builder.get_object('show_appmenu_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-window-previews',
                             this._builder.get_object('show_window_previews_switch'),
                             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -59,6 +59,11 @@
       <summary>Show activities button</summary>
       <description>Show activities button on the left hand side of the taskbar</description>
     </key>
+    <key type="b" name="show-appmenu">
+      <default>false</default>
+      <summary>Show appMenu</summary>
+      <description>Show appMenu on the right hand side of the panel</description>
+    </key>
     <key type="b" name="show-window-previews">
       <default>true</default>
       <summary>Show window preview</summary>


### PR DESCRIPTION
Option to show the AppMenu on the right hand side of the panel. This is the tweak I described in #2.

**Edit:** I didn't test this enough. The menu get unhidden after showing the activities overview.

**Edit2:** everything should work