### PR TITLE
Hotkeys: fix unnecessary rewriting of settings

### DIFF
--- a/overview.js
+++ b/overview.js
@@ -177,63 +177,7 @@ const dtpOverview = new Lang.Class({
                     else
                         Lang.bind(this, this._disableHotKeys)();
             })
-        ],[
-            this._dtpSettings,
-            'changed::hotkey-prefix-text',
-            Lang.bind(this, this._checkHotkeyPrefix)
         ]);
-    },
-
-    _checkHotkeyPrefix: function() {
-        this._dtpSettings.delay();
-
-        let hotkeyPrefix = this._dtpSettings.get_string('hotkey-prefix-text');
-        if (hotkeyPrefix == 'Super')
-           hotkeyPrefix = '<Super>';
-        else if (hotkeyPrefix == 'SuperAlt')
-           hotkeyPrefix = '<Super><Alt>';
-        let [, mods]       = Gtk.accelerator_parse(hotkeyPrefix);
-        let [, shift_mods] = Gtk.accelerator_parse('<Shift>' + hotkeyPrefix);
-        let [, ctrl_mods]  = Gtk.accelerator_parse('<Ctrl>'  + hotkeyPrefix);
-
-        for (let i = 1; i <= this._numHotkeys; i++) {
-            let number = i;
-            if (number == 10)
-                number = 0;
-            let key    = Gdk.keyval_from_name(number.toString());
-            let key_kp = Gdk.keyval_from_name('KP_' + number.toString());
-            if (Gtk.accelerator_valid(key, mods)) {
-                let shortcut    = Gtk.accelerator_name(key, mods);
-                let shortcut_kp = Gtk.accelerator_name(key_kp, mods);
-
-                // Setup shortcut strings
-                this._dtpSettings.set_strv('app-hotkey-'    + i, [shortcut]);
-                this._dtpSettings.set_strv('app-hotkey-kp-' + i, [shortcut_kp]);
-
-                // With <Shift>
-                shortcut    = Gtk.accelerator_name(key, shift_mods);
-                shortcut_kp = Gtk.accelerator_name(key_kp, shift_mods);
-                this._dtpSettings.set_strv('app-shift-hotkey-'    + i, [shortcut]);
-                this._dtpSettings.set_strv('app-shift-hotkey-kp-' + i, [shortcut_kp]);
-
-                // With <Control>
-                shortcut    = Gtk.accelerator_name(key, ctrl_mods);
-                shortcut_kp = Gtk.accelerator_name(key_kp, ctrl_mods);
-                this._dtpSettings.set_strv('app-ctrl-hotkey-'    + i, [shortcut]);
-                this._dtpSettings.set_strv('app-ctrl-hotkey-kp-' + i, [shortcut_kp]);
-            }
-            else {
-                // Reset default settings for the relevant keys if the
-                // accelerators are invalid
-                let keys = ['app-hotkey-' + i, 'app-shift-hotkey-' + i, 'app-ctrl-hotkey-' + i,  // Regular numbers
-                            'app-hotkey-kp-' + i, 'app-shift-hotkey-kp-' + i, 'app-ctrl-hotkey-kp-' + i]; // Key-pad numbers
-                keys.forEach(function(val) {
-                    this._dtpSettings.set_value(val, this._dtpSettings.get_default_value(val));
-                }, this);
-            }
-        }
-
-        this._dtpSettings.apply();
     },
 
     _enableHotKeys: function() {

--- a/overview.js
+++ b/overview.js
@@ -186,7 +186,7 @@ const dtpOverview = new Lang.Class({
 
     _checkHotkeyPrefix: function() {
         this._dtpSettings.delay();
-        
+
         let hotkeyPrefix = this._dtpSettings.get_string('hotkey-prefix-text');
         if (hotkeyPrefix == 'Super')
            hotkeyPrefix = '<Super>';
@@ -239,8 +239,6 @@ const dtpOverview = new Lang.Class({
     _enableHotKeys: function() {
         if (this._hotKeysEnabled)
             return;
-
-        this._checkHotkeyPrefix();
 
         // Setup keyboard bindings for taskbar elements
         let keys = ['app-hotkey-', 'app-shift-hotkey-', 'app-ctrl-hotkey-',  // Regular numbers


### PR DESCRIPTION
Hi,
As discussed, I improved a bit the hotkeys section.

The first commit is actually enough, as it removes the (unnecessary) call to re-write the settings on every boot.
The second commit moves the function to prefs.js, as you suggested we should do.

Let me know what you think!