### PR TITLE
Correct top and bottom margin in fine-tune tab

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -2476,6 +2476,8 @@
         <property name="can_focus">False</property>
         <property name="margin_left">24</property>
         <property name="margin_right">24</property>
+	<property name="margin_top">24</property>
+	<property name="margin_bottom">24</property>
         <property name="orientation">vertical</property>
         <property name="spacing">24</property>
         <child>


### PR DESCRIPTION
Add a space between the tab and the first settings box in fine-tune.