### PR TITLE
Fixes #119

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -139,7 +139,8 @@ const Settings = new Lang.Class({
         this._builder.set_translation_domain(Me.metadata['gettext-domain']);
         this._builder.add_from_file(Me.path + '/Settings.ui');
 
-        this.widget = this._builder.get_object('settings_notebook');
+        this.widget = new Gtk.ScrolledWindow();
+        this.widget.add_with_viewport(this._builder.get_object('settings_notebook');
 
         // Timeout to delay the update of the settings
         this._panel_size_timeout = 0;


### PR DESCRIPTION
With a laptop screen
![screenshot from 2017-04-29 18-53-22](https://cloud.githubusercontent.com/assets/7660997/25557203/2f874db0-2d0d-11e7-9fca-15a1e135bb6b.png)

Sadly, we can't use a Gtk.Window directly for the pref settings object. If we do so, gnome-shell will draw a Gtk Window +  the gtk Window provided by the extension itself... Otherwise i would have used a Gtk Stack & Gtk StackSwitcher as a custom titlebar for the Headerbar :-)
Anyway this works as expected !
