### PR TITLE
Number overlay: optional transitivity and minor improvements

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1378,11 +1378,15 @@
                     <property name="margin_bottom">12</property>
                     <property name="column_spacing">32</property>
                     <child>
-                      <object class="GtkSwitch" id="overlay_switch">
+                      <object class="GtkComboBoxText" id="overlay_combo">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="halign">end</property>
+                        <property name="can_focus">False</property>
                         <property name="valign">center</property>
+                        <items>
+                          <item id="NEVER"       translatable="yes">Never</item>
+                          <item id="TEMPORARILY" translatable="yes">Show temporarily</item>
+                          <item id="ALWAYS"      translatable="yes">Always visible</item>
+                        </items>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -1485,7 +1489,7 @@
                     <property name="column_spacing">32</property>
                     <child>
                       <object class="GtkEntry" id="shortcut_entry">
-                        <property name="can_focus">False</property>
+                        <property name="can_focus">True</property>
                         <property name="valign">center</property>
                         <property name="width_chars">12</property>
                       </object>

--- a/appIcons.js
+++ b/appIcons.js
@@ -719,10 +719,14 @@ const taskbarAppIcon = new Lang.Class({
     },
 
     updateNumberOverlay: function() {
+        // We apply an overall scale factor that might come from a HiDPI monitor.
+        // Clutter dimensions are in physical pixels, but CSS measures are in logical
+        // pixels, so make sure to consider the scale.
+        let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
         // Set the font size to something smaller than the whole icon so it is
         // still visible. The border radius is large to make the shape circular
         let [minWidth, natWidth] = this._iconContainer.get_preferred_width(-1);
-        let font_size =  Math.round(Math.max(12, 0.3*natWidth));
+        let font_size =  Math.round(Math.max(12, 0.3*natWidth) / scaleFactor);
         let size = Math.round(font_size*1.2);
         this._numberOverlayLabel.set_style(
             this._numberOverlayStyle +

--- a/overview.js
+++ b/overview.js
@@ -231,10 +231,6 @@ const dtpOverview = new Lang.Class({
             this._dtpSettings,
             'changed::hotkeys-overlay',
             Lang.bind(this, this._checkHotkeysOptions)
-        ], [
-            this._dtpSettings,
-            'changed::shortcut-text',
-            Lang.bind(this, this._checkHotkeysOptions)
         ]);
     },
 
@@ -246,9 +242,7 @@ const dtpOverview = new Lang.Class({
     },
 
     _enableExtraShortcut: function() {
-        let shortcut_is_valid = this._setShortcut();
-
-        if (shortcut_is_valid && !this._shortcutIsSet) {
+        if (!this._shortcutIsSet) {
             Main.wm.addKeybinding('shortcut', this._dtpSettings,
                                   Meta.KeyBindingFlags.NONE,
                                   Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
@@ -257,21 +251,6 @@ const dtpOverview = new Lang.Class({
                                       this._showOverlay();
                                   }));
             this._shortcutIsSet = true;
-        }
-    },
-
-    _setShortcut: function() {
-        let shortcut_text = this._dtpSettings.get_string('shortcut-text');
-        let [key, mods] = Gtk.accelerator_parse(shortcut_text);
-
-        if (Gtk.accelerator_valid(key, mods)) {
-            let shortcut = Gtk.accelerator_name(key, mods);
-            this._dtpSettings.set_strv('shortcut', [shortcut]);
-            return true;
-        }
-        else {
-            this._dtpSettings.set_strv('shortcut', []);
-            return false;
         }
     },
 

--- a/overview.js
+++ b/overview.js
@@ -201,6 +201,9 @@ const dtpOverview = new Lang.Class({
         }, this);
 
         this._hotKeysEnabled = true;
+
+        if (this._dtpSettings.get_string('hotkeys-overlay-combo') === 'ALWAYS')
+            this.taskbar.toggleNumberOverlay(true);
     },
 
     _disableHotKeys: function() {
@@ -215,6 +218,8 @@ const dtpOverview = new Lang.Class({
         }, this);
 
         this._hotKeysEnabled = false;
+
+        this.taskbar.toggleNumberOverlay(false);
     },
 
     _optionalNumberOverlay: function() {
@@ -229,8 +234,13 @@ const dtpOverview = new Lang.Class({
             Lang.bind(this, this._checkHotkeysOptions)
         ], [
             this._dtpSettings,
-            'changed::hotkeys-overlay',
-            Lang.bind(this, this._checkHotkeysOptions)
+            'changed::hotkeys-overlay-combo',
+            Lang.bind(this, function() {
+                if (this._dtpSettings.get_string('hotkeys-overlay-combo') === 'ALWAYS')
+                    this.taskbar.toggleNumberOverlay(true);
+                else
+                    this.taskbar.toggleNumberOverlay(false);
+            })
         ]);
     },
 
@@ -262,14 +272,20 @@ const dtpOverview = new Lang.Class({
     },
 
     _showOverlay: function() {
-        if (this._dtpSettings.get_boolean('hotkeys-overlay') || this._overlayFromShortcut)
-            this.taskbar.toggleNumberOverlay(true);
-
         // Restart the counting if the shortcut is pressed again
         if (this._numberOverlayTimeoutId) {
             Mainloop.source_remove(this._numberOverlayTimeoutId);
             this._numberOverlayTimeoutId = 0;
         }
+
+        let hotkey_option = this._dtpSettings.get_string('hotkeys-overlay-combo');
+
+        // Set to true and exit if the overlay is always visible
+        if (hotkey_option === 'ALWAYS')
+            return;
+
+        if (hotkey_option === 'TEMPORARILY' || this._overlayFromShortcut)
+            this.taskbar.toggleNumberOverlay(true);
 
         let timeout = this._dtpSettings.get_int('overlay-timeout');
         if (this._overlayFromShortcut) {

--- a/prefs.js
+++ b/prefs.js
@@ -74,6 +74,19 @@ function cssHexString(css) {
     return rrggbb;
 }
 
+function setShortcut(settings) {
+    let shortcut_text = settings.get_string('shortcut-text');
+    let [key, mods] = Gtk.accelerator_parse(shortcut_text);
+
+    if (Gtk.accelerator_valid(key, mods)) {
+        let shortcut = Gtk.accelerator_name(key, mods);
+        settings.set_strv('shortcut', [shortcut]);
+    }
+    else {
+        settings.set_strv('shortcut', []);
+    }
+}
+
 function checkHotkeyPrefix(settings) {
     settings.delay();
 
@@ -597,6 +610,7 @@ const Settings = new Lang.Class({
                                 this._builder.get_object('shortcut_entry'),
                                 'text',
                                 Gio.SettingsBindFlags.DEFAULT);
+            this._settings.connect('changed::shortcut-text', Lang.bind(this, function() {setShortcut(this._settings);}));
 
             dialog.connect('response', Lang.bind(this, function(dialog, id) {
                 if (id == 1) {

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -291,11 +291,6 @@
       <summary>Timeout to hide the dock, in seconds</summary>
       <description>Sets the time duration before the dock is hidden again.</description>
     </key>
-    <key type="b" name="hotkeys-overlay">
-      <default>true</default>
-      <summary>Show the dock when using the hotkeys</summary>
-      <description>The dock will be quickly shown so that the number-overlay is visible and app activation is easier</description>
-    </key>
     <key name="hotkeys-overlay-combo" enum="org.gnome.shell.extensions.dash-to-panel.hotkeyOverlay">
       <default>'TEMPORARILY'</default>
       <summary>Transitivity of the number overlay</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -26,6 +26,11 @@
     <value value='0' nick='Super'/>
     <value value='1' nick='SuperAlt'/>
   </enum>
+  <enum id='org.gnome.shell.extensions.dash-to-panel.hotkeyOverlay'>
+    <value value='0' nick='NEVER'/>
+    <value value='1' nick='TEMPORARILY'/>
+    <value value='2' nick='ALWAYS'/>
+  </enum>
   <!-- this is mean to Match StSide. LEFT and RIGHT actual position in reversed in
        rtl languages -->
   <enum id='org.gnome.shell.extensions.dash-to-panel.panelPosition'>
@@ -290,6 +295,11 @@
       <default>true</default>
       <summary>Show the dock when using the hotkeys</summary>
       <description>The dock will be quickly shown so that the number-overlay is visible and app activation is easier</description>
+    </key>
+    <key name="hotkeys-overlay-combo" enum="org.gnome.shell.extensions.dash-to-panel.hotkeyOverlay">
+      <default>'TEMPORARILY'</default>
+      <summary>Transitivity of the number overlay</summary>
+      <description>You can choose between NEVER, TEMPORARILY and ALWAYS.</description>
     </key>
     <key type="b" name="hot-keys">
       <default>false</default>

--- a/taskbar.js
+++ b/taskbar.js
@@ -865,6 +865,9 @@ const taskbar = new Lang.Class({
             icon.updateNumberOverlay();
         });
 
+        if (this._dtpSettings.get_boolean('hot-keys') &&
+            this._dtpSettings.get_string('hotkeys-overlay-combo') === 'ALWAYS')
+            this.toggleNumberOverlay(true);
     },
 
     toggleNumberOverlay: function(activate) {


### PR DESCRIPTION
* This hopefully addresses #174 
* Moves the `setShortcut()` function to prefs.js for better performance when enabling
* It also fixes a small problem with the shortcut not being configurable