### PR TITLE
windowPreview.js: two small fixes.

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -220,7 +220,7 @@ const taskbarAppIcon = new Lang.Class({
         // resulting in an error when assigned to the a rect. This is a more like
         // a workaround to prevent flooding the system with errors.
         if (this.actor.get_stage() == null)
-            return
+            return;
 
         let rect = new Meta.Rectangle();
 
@@ -719,6 +719,11 @@ const taskbarAppIcon = new Lang.Class({
     },
 
     updateNumberOverlay: function() {
+        // If (for unknown reason) the actor is not on the stage the reported size
+        // and position are random values. This is a more like a workaround to
+        // prevent flooding the system with errors.
+        if (this._iconContainer.get_stage() == null)
+            return;
         // Set the font size to something smaller than the whole icon so it is
         // still visible. The border radius is large to make the shape circular
         let [minWidth, natWidth] = this._iconContainer.get_preferred_width(-1);

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -502,9 +502,9 @@ const thumbnailPreview = new Lang.Class({
                                   });
         this._titleBin.add_style_class_name("preview-window-title");
 
-        this.window.connect('notify::title', Lang.bind(this, function() {
-                            this._title.set_text(this.window.title);
-                            }));
+        this._windowTitleId = this.window.connect('notify::title', Lang.bind(this, function() {
+                                  this._title.set_text(this.window.title);
+                              }));
 
         this._windowBin = new St.Bin({ child: this.overlayGroup,
                                     x_align: St.Align.MIDDLE,
@@ -530,6 +530,24 @@ const thumbnailPreview = new Lang.Class({
                                   Lang.bind(this, this._onLeave));
         this.actor.connect('motion-event',
                                   Lang.bind(this, this._onMotionEvent));
+    },
+
+    _onDestroy: function() {
+        if (this.window &&
+            this._windowTitleId > 0) {
+            this.window.disconnect(this._windowTitleId);
+            this._windowTitleId = 0;
+        }
+
+        if (this.window &&
+            this.window.get_compositor_private() &&
+            this.window.get_compositor_private().meta_window &&
+            this._resizeId) {
+            this.window.get_compositor_private().meta_window.disconnect(this._resizeId);
+            this._resizeId = 0
+        }
+
+        this.parent();
     },
 
     _onEnter: function(actor, event) {


### PR DESCRIPTION
This tries to avoid errors (and hopefully crashes) when using window previews.
Particularly, it helps a bit when closing applications and/or when
locking/unlocking the screen the srceen.

_onDestroy():
1. disconnect the signal to `_queueResize()`
2. disconnect the `notify::title` signal

I don't know if it's enough to fix https://github.com/jderose9/dash-to-panel/issues/170, but I hope at least it can help a bit.