### PR TITLE
Support middle click on preview to close window and right click to show context menu

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1263,6 +1263,70 @@
                 </child>
               </object>
             </child>
+            <child>
+              <object class="GtkListBoxRow" id="listbox_preview_middle_click_close">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_preview_middle_click_close">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkLabel" id="preview_middle_click_close_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">Middle click to close window</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="preview_middle_click_close_switch">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="preview_middle_click_close_description">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">Middle click on the preview to close the window.</property>
+                        <property name="wrap">True</property>
+                        <property name="max_width_chars">40</property>
+                        <property name="xalign">0</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/prefs.js
+++ b/prefs.js
@@ -439,6 +439,10 @@ const Settings = new Lang.Class({
                             this._builder.get_object('listboxrow_peek_mode_opacity'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
+            this._settings.bind('preview-middle-click-close',
+                            this._builder.get_object('preview_middle_click_close_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
 
             this._builder.get_object('enter_peek_mode_timeout_spinbutton').set_value(this._settings.get_int('enter-peek-mode-timeout'));
 
@@ -463,6 +467,7 @@ const Settings = new Lang.Class({
                     this._builder.get_object('enter_peek_mode_timeout_spinbutton').set_value(this._settings.get_int('enter-peek-mode-timeout'));
                     this._settings.set_value('peek-mode-opacity', this._settings.get_default_value('peek-mode-opacity'));
                     this._builder.get_object('peek_mode_opacity_spinbutton').set_value(this._settings.get_int('peek-mode-opacity'));
+                    this._settings.set_value('preview-middle-click-close', this._settings.get_default_value('preview-middle-click-close'));
 
                 } else {
                     // remove the settings box so it doesn't get destroyed;

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -225,6 +225,11 @@
       <summary>Window peeking mode opacity</summary>
       <description>All windows except for the peeked one have their opacity set to the same value.</description>
     </key>
+    <key type="b" name="preview-middle-click-close">
+      <default>false</default>
+      <summary>Middle click preview to close window</summary>
+      <description>Middle click on the window preview to close that window</description>
+    </key>
     <key type="i" name="tray-size">
       <default>0</default>
       <summary>Tray font size</summary>

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -767,7 +767,9 @@ const thumbnailPreview = new Lang.Class({
                 break;
             case 2:
                 // Middle click
-                this._closeWindow();
+                if (this._getTopMenu()._dtpSettings.get_boolean('preview-middle-click-close')) {
+                    this._closeWindow();
+                }
                 break;
             case 3:
                 // Right click

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -750,6 +750,17 @@ const thumbnailPreview = new Lang.Class({
                 }));
             }
         }
+    },
+
+    _onButtonReleaseEvent: function(actor, event) {
+        this.actor.remove_style_pseudo_class ('active');
+        if (event.get_button() == 2) {
+            // Middle click
+            this._closeWindow();
+        } else {
+            this.activate(event);
+        }
+        return Clutter.EVENT_STOP;
     }
 });
 


### PR DESCRIPTION
This PR adds support for middle clicking a window preview to close that window, and right clicking the preview to show the same context menu as right clicking on a window title bar (minimise, close etc).