### PR TITLE
Fix minor JS warnings on gnome-shell 3.26

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -91,7 +91,7 @@ let tracker = Shell.WindowTracker.get_default();
  *
  */
 
-const taskbarAppIcon = new Lang.Class({
+var taskbarAppIcon = new Lang.Class({
     Name: 'DashToPanel.TaskbarAppIcon',
     Extends: AppDisplay.AppIcon,
 
@@ -941,7 +941,7 @@ function getInterestingWindows(app, settings) {
  *   (https://github.com/deuill/shell-extension-quitfromdash)
  */
 
-const taskbarSecondaryMenu = new Lang.Class({
+var taskbarSecondaryMenu = new Lang.Class({
     Name: 'DashToPanel.SecondaryMenu',
     Extends: AppDisplay.AppIconMenu,
 
@@ -1207,7 +1207,7 @@ function extendShowAppsIcon(showAppsIcon, settings) {
 /**
  * A menu for the showAppsIcon
  */
-const MyShowAppsIconMenu = new Lang.Class({
+var MyShowAppsIconMenu = new Lang.Class({
     Name: 'DashToPanel.ShowAppsIconMenu',
     Extends: taskbarSecondaryMenu,
 

--- a/convenience.js
+++ b/convenience.js
@@ -92,7 +92,7 @@ function getSettings(schema) {
 
 // simplify global signals and function injections handling
 // abstract class
-const BasicHandler = new Lang.Class({
+var BasicHandler = new Lang.Class({
     Name: 'DashToPanel.BasicHandler',
 
     _init: function(){
@@ -148,7 +148,7 @@ const BasicHandler = new Lang.Class({
 });
 
 // Manage global signals
-const GlobalSignalsHandler = new Lang.Class({
+var GlobalSignalsHandler = new Lang.Class({
     Name: 'DashToPanel.GlobalSignalsHandler',
     Extends: BasicHandler,
 
@@ -171,7 +171,7 @@ const GlobalSignalsHandler = new Lang.Class({
  * Manage function injection: both instances and prototype can be overridden
  * and restored
  */
-const InjectionsHandler = new Lang.Class({
+var InjectionsHandler = new Lang.Class({
     Name: 'DashToPanel.InjectionsHandler',
     Extends: BasicHandler,
 

--- a/overview.js
+++ b/overview.js
@@ -31,7 +31,7 @@ const Mainloop = imports.mainloop;
 
 const Meta = imports.gi.Meta;
 
-const dtpOverview = new Lang.Class({
+var dtpOverview = new Lang.Class({
     Name: 'DashToPanel.Overview',
 
     _numHotkeys: 10,

--- a/panel.js
+++ b/panel.js
@@ -49,7 +49,7 @@ const ViewSelector = imports.ui.viewSelector;
 
 let tracker = Shell.WindowTracker.get_default();
 
-const dtpPanel = new Lang.Class({
+var dtpPanel = new Lang.Class({
     Name: 'DashToPanel.Panel',
 
     _init: function(settings) {

--- a/panelStyle.js
+++ b/panelStyle.js
@@ -31,7 +31,7 @@ const Shell = imports.gi.Shell;
 
 const Taskbar = Me.imports.taskbar;
 
-const dtpPanelStyle = new Lang.Class({
+var dtpPanelStyle = new Lang.Class({
     Name: 'DashToPanel.PanelStyle',
 
     _init: function(settings) {

--- a/taskbar.js
+++ b/taskbar.js
@@ -78,7 +78,7 @@ function extendDashItemContainer(dashItemContainer) {
  * - handle horizontal dash
  */
 
-const taskbarActor = new Lang.Class({
+var taskbarActor = new Lang.Class({
     Name: 'DashToPanel.TaskbarActor',
 
     _init: function() {
@@ -160,7 +160,7 @@ const taskbarActor = new Lang.Class({
 
 const baseIconSizes = [ 16, 22, 24, 32, 48, 64, 96, 128 ];
 
-const taskbar = new Lang.Class({
+var taskbar = new Lang.Class({
     Name: 'DashToPanel.Taskbar',
 
     _init : function(settings) {

--- a/taskbar.js
+++ b/taskbar.js
@@ -49,10 +49,10 @@ const Convenience = Me.imports.convenience;
 const WindowPreview = Me.imports.windowPreview;
 const AppIcons = Me.imports.appIcons;
 
-let DASH_ANIMATION_TIME = Dash.DASH_ANIMATION_TIME;
+var DASH_ANIMATION_TIME = Dash.DASH_ANIMATION_TIME;
 let DASH_ITEM_LABEL_SHOW_TIME = Dash.DASH_ITEM_LABEL_SHOW_TIME;
 let DASH_ITEM_LABEL_HIDE_TIME = Dash.DASH_ITEM_LABEL_HIDE_TIME;
-let DASH_ITEM_HOVER_TIMEOUT = Dash.DASH_ITEM_HOVER_TIMEOUT;
+var DASH_ITEM_HOVER_TIMEOUT = Dash.DASH_ITEM_HOVER_TIMEOUT;
 let HFADE_WIDTH = 48;
 
 function getPosition() {

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -47,7 +47,7 @@ const AppIcons = Me.imports.appIcons;
 let DEFAULT_THUMBNAIL_WIDTH = 350;
 let DEFAULT_THUMBNAIL_HEIGHT = 200;
 
-const thumbnailPreviewMenu = new Lang.Class({
+var thumbnailPreviewMenu = new Lang.Class({
     Name: 'DashToPanel.ThumbnailPreviewMenu',
     Extends: PopupMenu.PopupMenu,
 
@@ -485,7 +485,7 @@ const thumbnailPreviewMenu = new Lang.Class({
     }
 });
 
-const thumbnailPreview = new Lang.Class({
+var thumbnailPreview = new Lang.Class({
     Name: 'DashToPanel.ThumbnailPreview',
     Extends: PopupMenu.PopupBaseMenuItem,
 
@@ -818,7 +818,7 @@ const thumbnailPreview = new Lang.Class({
     }
 });
 
-const thumbnailPreviewList = new Lang.Class({
+var thumbnailPreviewList = new Lang.Class({
     Name: 'DashToPanel.ThumbnailPreviewList',
     Extends: PopupMenu.PopupMenuSection,
 
@@ -1080,7 +1080,7 @@ const thumbnailPreviewList = new Lang.Class({
     }
 });
 
-const previewMenuPopup = new Lang.Class({
+var previewMenuPopup = new Lang.Class({
     Name: 'previewMenuPopup',
     Extends: WindowMenu.WindowMenu,
 
@@ -1096,7 +1096,7 @@ const previewMenuPopup = new Lang.Class({
     // Otherwise, just let the parent do its thing?
 });
 
-const previewMenuPopupManager = new Lang.Class({
+var previewMenuPopupManager = new Lang.Class({
     Name: 'previewMenuPopupManagerTest',
     
     _init: function(window, source) {


### PR DESCRIPTION
This pull-request fixes some minor JS warnings that occur on gnome-shell 3.26. We faced the same JS warnings in Arc-Menu. For simplicity reasons, we basically defined all classes using 'var' instead of 'const'.

Example JS warnings:
```
Some code accessed the property XYZ on the module ABC. That property was defined with 'let' or 
'const' inside the module. This was previously supported, but is not correct according to the ES6 
standard. Any symbols to be exported from a module must be defined with 'var'. The property 
access will work as previously for the time being, but please fix your code anyway.

```