### PR TITLE
windowPreview: disconnect from window title changes on actor destroy

### DIFF
--- a/windowPreview.js
+++ b/windowPreview.js
@@ -495,7 +495,7 @@ const thumbnailPreview = new Lang.Class({
         let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
         if(!scaleFactor)
             scaleFactor = 1;
-        
+
         this._thumbnailWidth = DEFAULT_THUMBNAIL_WIDTH*scaleFactor;
         this._thumbnailHeight = DEFAULT_THUMBNAIL_HEIGHT*scaleFactor;
 
@@ -534,9 +534,9 @@ const thumbnailPreview = new Lang.Class({
                                   });
         this._titleBin.add_style_class_name("preview-window-title");
 
-        this.window.connect('notify::title', Lang.bind(this, function() {
-                            this._title.set_text(this.window.title);
-                            }));
+        this._titleNotifyId = this.window.connect('notify::title', Lang.bind(this, function() {
+                                                   this._title.set_text(this.window.title);
+                                               }));
 
         this._windowBin = new St.Bin({ child: this.overlayGroup,
                                     x_align: St.Align.MIDDLE,
@@ -562,6 +562,8 @@ const thumbnailPreview = new Lang.Class({
                                   Lang.bind(this, this._onLeave));
         this.actor.connect('motion-event',
                                   Lang.bind(this, this._onMotionEvent));
+        this.actor.connect('destroy',
+                                  Lang.bind(this, this._onDestroy));
 
         this._previewMenuPopupManager = new previewMenuPopupManager(window, this.actor);
     },
@@ -815,6 +817,11 @@ const thumbnailPreview = new Lang.Class({
             width: 0,
             height: 0
         });
+    },
+
+    _onDestroy: function() {
+        this.window.disconnect(this._titleNotifyId);
+        this._titleNotifyId = 0;
     }
 });
 


### PR DESCRIPTION
When a popup is destroyed, the window might still emit signals of
title changed, causing crashes in gnome-shell

We're getting multiple crash reports about this in both Ubuntu (https://pad.lv/1714989) and upstream GNOME (https://bugzilla.gnome.org/show_bug.cgi?id=788931)