### PR TITLE
Add the feature to move taskbar in center panel, including user settings

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -2166,6 +2166,77 @@
             <property name="position">2</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkFrame" id="taskbar_display">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkListBox" id="taskbar_display_listbox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selection_mode">none</property>
+                <child>
+                  <object class="GtkListBoxRow" id="taskbar_position_listboxrow">
+                    <property name="width_request">100</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="taskbar_position_grid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="row_spacing">32</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="taskbar_position_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Taskbar position</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="taskbar_position_combo">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="valign">center</property>
+                            <items>
+                              <item id="LEFTPANEL" translatable="yes">Left panel</item>
+                              <item id="CENTEREDMONITOR" translatable="yes">Centered in monitor</item>
+                              <item id="CENTEREDCENTER" translatable="yes">Centered in center panel</item>
+                            </items>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label_item">
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
       </object>
     </child>
     <child type="tab">

--- a/Settings.ui
+++ b/Settings.ui
@@ -2213,7 +2213,7 @@
                             <items>
                               <item id="LEFTPANEL" translatable="yes">Left panel</item>
                               <item id="CENTEREDMONITOR" translatable="yes">Centered in monitor</item>
-                              <item id="CENTEREDCENTER" translatable="yes">Centered in center panel</item>
+                              <item id="CENTEREDCONTENT" translatable="yes">Centered in content</item>
                             </items>
                           </object>
                           <packing>

--- a/panel.js
+++ b/panel.js
@@ -448,11 +448,20 @@ var dtpPanel = new Lang.Class({
     },
     
     _setAppmenuVisible: function(isVisible) {
-        let centerBox = this.panel._centerBox;
-        if (isVisible && centerBox.get_children().indexOf(this.appMenu.container) == -1) {
-            centerBox.insert_child_at_index(this.appMenu.container, 0)
-        } else if (!isVisible && centerBox.get_children().indexOf(this.appMenu.container) != -1) {
-            centerBox.remove_child(this.appMenu.container);
+        if (this._dtpSettings.get_string('taskbar-position') == 'LEFTPANEL') {
+            let centerBox = this.panel._centerBox;
+            if (isVisible && centerBox.get_children().indexOf(this.appMenu.container) == -1) {
+                centerBox.insert_child_at_index(this.appMenu.container, 0);
+            } else if (!isVisible && centerBox.get_children().indexOf(this.appMenu.container) != -1) {
+                centerBox.remove_child(this.appMenu.container);
+            }
+        } else {
+            let leftBox = this.panel._leftBox;
+            if (isVisible && leftBox.get_children().indexOf(this.appMenu.container) == -1) {
+                leftBox.insert_child_above(this.appMenu.container, null);
+            } else if (!isVisible && leftBox.get_children().indexOf(this.appMenu.container) != -1) {
+                leftBox.remove_child(this.appMenu.container);
+            }
         }
     },
 

--- a/panel.js
+++ b/panel.js
@@ -338,41 +338,59 @@ var dtpPanel = new Lang.Class({
         let [centerMinWidth, centerNaturalWidth] = this.panel._centerBox.get_preferred_width(-1);
         let [rightMinWidth, rightNaturalWidth] = this.panel._rightBox.get_preferred_width(-1);
 
-	//I use ctb and cim variables to make diff reading easier. This must be replaced by if loups.
         let taskbarPosition = this._dtpSettings.get_string('taskbar-position');
-        let ctb = (taskbarPosition != 'LEFTPANEL'); // ctb: centered taskbar
-        let cim = (taskbarPosition == 'CENTEREDMONITOR'); // cim: centered in monitor
-
         let sideWidth, leftSideWidth, rightSideWidth;
-        if(ctb && !cim) {
+        
+        if (taskbarPosition == 'LEFTPANEL') {
+            sideWidth = allocWidth - rightNaturalWidth - centerNaturalWidth;
+        } else if (taskbarPosition == 'CENTEREDCENTER') {
             leftSideWidth = (allocWidth - centerNaturalWidth + leftNaturalWidth - rightNaturalWidth) / 2;
             rightSideWidth = (allocWidth - centerNaturalWidth - leftNaturalWidth + rightNaturalWidth) / 2;
-            sideWidth = 0;
-        } else {
-            sideWidth = leftSideWidth = rightSideWidth = (!ctb)*(allocWidth - rightNaturalWidth - centerNaturalWidth) + ctb*((allocWidth - centerNaturalWidth) / 2);
+        } else if (taskbarPosition == 'CENTEREDMONITOR') {
+            leftSideWidth = rightSideWidth = sideWidth = (allocWidth - centerNaturalWidth) / 2;
         }
-
+        
         let childBox = new Clutter.ActorBox();
-
+        
         childBox.y1 = 0;
         childBox.y2 = allocHeight;
-        if (this.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
-            childBox.x1 = allocWidth - ctb*leftNaturalWidth - (!ctb)*sideWidth;
-            childBox.x2 = allocWidth;
+        if (taskbarPosition == 'LEFTPANEL') {
+            if (this.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
+                childBox.x1 = allocWidth - Math.min(Math.floor(sideWidth), leftNaturalWidth);
+                childBox.x2 = allocWidth;
+            } else {
+                childBox.x1 = 0;
+                childBox.x2 = sideWidth;
+            }
         } else {
-            childBox.x1 = 0;
-            childBox.x2 = ctb*leftNaturalWidth + (!ctb)*sideWidth;
+            if (this.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
+                childBox.x1 = allocWidth - leftNaturalWidth;
+                childBox.x2 = allocWidth;
+            } else {
+                childBox.x1 = 0;
+                childBox.x2 =leftNaturalWidth;
+            }
         }
         this.panel._leftBox.allocate(childBox, flags, true);
-
+        
         childBox.y1 = 0;
         childBox.y2 = allocHeight;
-        if (this.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
-            childBox.x1 = allocWidth - ctb*(allocWidth - Math.max(rightNaturalWidth, rightSideWidth)) - (!ctb)*(childBox.x1 + centerNaturalWidth);
-            childBox.x2 = allocWidth - ctb*(Math.max(leftNaturalWidth, leftSideWidth)) - (!ctb)*(allocWidth - centerNaturalWidth - rightNaturalWidth);
+        if (taskbarPosition == 'LEFTPANEL') {
+            if (this.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
+                childBox.x1 = rightNaturalWidth;
+                childBox.x2 = childBox.x1 + centerNaturalWidth;
+            } else {
+                childBox.x1 = allocWidth - centerNaturalWidth - rightNaturalWidth;
+                childBox.x2 = childBox.x1 + centerNaturalWidth;
+            }
         } else {
-            childBox.x1 = ctb*(Math.max(leftNaturalWidth, leftSideWidth)) + (!ctb)*(allocWidth - centerNaturalWidth - rightNaturalWidth);
-            childBox.x2 = ctb*(allocWidth - Math.max(rightNaturalWidth, rightSideWidth)) + (!ctb)*(childBox.x1 + centerNaturalWidth);
+            if (this.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
+                childBox.x1 = Math.max(rightNaturalWidth, rightSideWidth);
+                childBox.x2 = allocWidth - Math.max(leftNaturalWidth, leftSideWidth);
+            } else {
+                childBox.x1 = Math.max(leftNaturalWidth, leftSideWidth);
+                childBox.x2 = allocWidth - Math.max(rightNaturalWidth, rightSideWidth);
+            }
         }
         this.panel._centerBox.allocate(childBox, flags, true);
 

--- a/panel.js
+++ b/panel.js
@@ -343,7 +343,7 @@ var dtpPanel = new Lang.Class({
         
         if (taskbarPosition == 'LEFTPANEL') {
             sideWidth = allocWidth - rightNaturalWidth - centerNaturalWidth;
-        } else if (taskbarPosition == 'CENTEREDCENTER') {
+        } else if (taskbarPosition == 'CENTEREDCONTENT') {
             leftSideWidth = (allocWidth - centerNaturalWidth + leftNaturalWidth - rightNaturalWidth) / 2;
             rightSideWidth = (allocWidth - centerNaturalWidth - leftNaturalWidth + rightNaturalWidth) / 2;
         } else if (taskbarPosition == 'CENTEREDMONITOR') {

--- a/prefs.js
+++ b/prefs.js
@@ -201,6 +201,10 @@ const Settings = new Lang.Class({
         this._builder.get_object('location_clock_combo').connect('changed', Lang.bind (this, function(widget) {
             this._settings.set_string('location-clock', widget.get_active_id());
         }));
+        this._builder.get_object('taskbar_position_combo').set_active_id(this._settings.get_string('taskbar-position'));
+        this._builder.get_object('taskbar_position_combo').connect('changed', Lang.bind (this, function(widget) {
+            this._settings.set_string('taskbar-position', widget.get_active_id());
+        }));
 
         // size options
         let panel_size_scale = this._builder.get_object('panel_size_scale');

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -22,6 +22,11 @@
     <value value='1' nick='STATUSLEFT'/>
     <value value='2' nick='STATUSRIGHT'/>
   </enum>
+  <enum id='org.gnome.shell.extensions.dash-to-panel.taskbarPosition'>
+    <value value='0' nick='LEFTPANEL'/>
+    <value value='1' nick='CENTEREDMONITOR'/>
+    <value value='2' nick='CENTEREDCENTER'/>
+  </enum>
   <enum id='org.gnome.shell.extensions.dash-to-panel.hotkeyPrefix'>
     <value value='0' nick='Super'/>
     <value value='1' nick='SuperAlt'/>
@@ -131,6 +136,11 @@
       <default>'STATUSLEFT'</default>
       <summary>Location of the clock</summary>
       <description>Set the location of the clock on the taskbar</description>
+    </key>
+    <key name="taskbar-position" enum="org.gnome.shell.extensions.dash-to-panel.taskbarPosition">
+      <default>'LEFTPANEL'</default>
+      <summary>Position of the taskbar</summary>
+      <description>Set the position of the taskbar on the panel</description>
     </key>
     <key type="b" name="show-show-apps-button">
       <default>true</default>

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -25,7 +25,7 @@
   <enum id='org.gnome.shell.extensions.dash-to-panel.taskbarPosition'>
     <value value='0' nick='LEFTPANEL'/>
     <value value='1' nick='CENTEREDMONITOR'/>
-    <value value='2' nick='CENTEREDCENTER'/>
+    <value value='2' nick='CENTEREDCONTENT'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-panel.hotkeyPrefix'>
     <value value='0' nick='Super'/>


### PR DESCRIPTION
Add the feature to move taskbar in center panel, including user settings
Finally there are three choices to dash-to-panel users:
- taskbar in left panel as currently
- taskbar in center panel, centered between the left and the right panel
- taskbar in center panel, centered in monitor without considering left and right panels size
Missing the translation of new pref.
And it would be maybe better to use "if" loops rather than logical operations with booleans "ctb" and "cim" in the calculation of allocation size in panel.js
