### PR TITLE
Add option to set the "show desktop button" width

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -967,7 +967,6 @@
     <property name="page_increment">100</property>
   </object>
   <object class="GtkAdjustment" id="group_apps_label_max_width_adjustment">
-    <property name="lower">0</property>
     <property name="upper">1000</property>
     <property name="step_increment">10</property>
     <property name="page_increment">100</property>
@@ -1278,6 +1277,12 @@
     <property name="upper">9999</property>
     <property name="step_increment">25</property>
     <property name="page_increment">100</property>
+  </object>
+  <object class="GtkAdjustment" id="show_showdesktop_width_adjustment">
+    <property name="lower">1</property>
+    <property name="upper">40</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkBox" id="box_advanced_options">
     <property name="visible">True</property>
@@ -1984,6 +1989,60 @@
                   </object>
                 </child>
               </object>
+            </child>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+  </object>
+  <object class="GtkBox" id="show_showdesktop_options">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkListBoxRow" id="listboxrow_show_showdesktop_width">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <child>
+          <object class="GtkGrid" id="grid_show_showdesktop_width">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">12</property>
+            <property name="margin_right">12</property>
+            <property name="margin_top">12</property>
+            <property name="margin_bottom">12</property>
+            <property name="column_spacing">32</property>
+            <child>
+              <object class="GtkLabel" id="show_showdesktop_width_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Show Desktop button width (px)</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinButton" id="show_showdesktop_width_spinbutton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="width_chars">4</property>
+                <property name="text" translatable="yes">0</property>
+                <property name="adjustment">show_showdesktop_width_adjustment</property>
+                <property name="numeric">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
             </child>
           </object>
         </child>
@@ -2827,18 +2886,6 @@
                         <property name="margin_bottom">12</property>
                         <property name="column_spacing">32</property>
                         <child>
-                          <object class="GtkSwitch" id="show_showdesktop_button_switch">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
                           <object class="GtkLabel" id="show_showdesktop_button_label">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -2849,6 +2896,55 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="show_showdesktop_box">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkButton" id="show_showdesktop_options_button">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="xalign">0.46000000834465027</property>
+                                <child>
+                                  <object class="GtkImage" id="image_window_previews_options2">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="icon_name">emblem-system-symbolic</property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="show_showdesktop_button_switch">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
                             <property name="top_attach">0</property>
                           </packing>
                         </child>

--- a/panel.js
+++ b/panel.js
@@ -328,6 +328,8 @@ var dtpPanel = new Lang.Class({
         this._dtpSettings.connect('changed::show-showdesktop-button', Lang.bind(this, function() {
             this._displayShowDesktopButton(this._dtpSettings.get_boolean('show-showdesktop-button'));
         }));
+
+        this._dtpSettings.connect('changed::showdesktop-button-width', () => this._setShowDesktopButtonWidth());
     },
 
     _allocate: function(actor, box, flags) {
@@ -531,6 +533,8 @@ var dtpPanel = new Lang.Class({
                             y_fill: true,
                             track_hover: true });
 
+            this._setShowDesktopButtonWidth();
+
             this._showDesktopButton.connect('button-press-event', Lang.bind(this, this._onShowDesktopButtonPress));
 
             this._showDesktopButton.connect('enter-event', Lang.bind(this, function(){
@@ -549,6 +553,12 @@ var dtpPanel = new Lang.Class({
             this.panel._rightBox.remove_child(this._showDesktopButton);
             this._showDesktopButton.destroy();
             this._showDesktopButton = null;
+        }
+    },
+
+    _setShowDesktopButtonWidth: function() {
+        if (this._showDesktopButton) {
+            this._showDesktopButton.set_style('width: ' + this._dtpSettings.get_int('showdesktop-button-width') + 'px;');
         }
     },
 

--- a/prefs.js
+++ b/prefs.js
@@ -430,6 +430,46 @@ const Settings = new Lang.Class({
                             this._builder.get_object('show_showdesktop_button_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-showdesktop-button',
+                            this._builder.get_object('show_showdesktop_options_button'),
+                            'sensitive',
+                            Gio.SettingsBindFlags.DEFAULT);
+
+        this._builder.get_object('show_showdesktop_options_button').connect('clicked', Lang.bind(this, function() {
+
+            let dialog = new Gtk.Dialog({ title: _('Show Desktop options'),
+                                          transient_for: this.widget.get_toplevel(),
+                                          use_header_bar: true,
+                                          modal: true });
+
+            // GTK+ leaves positive values for application-defined response ids.
+            // Use +1 for the reset action
+            dialog.add_button(_('Reset to defaults'), 1);
+
+            let box = this._builder.get_object('show_showdesktop_options');
+            dialog.get_content_area().add(box);
+
+            this._builder.get_object('show_showdesktop_width_spinbutton').set_value(this._settings.get_int('showdesktop-button-width'));
+            this._builder.get_object('show_showdesktop_width_spinbutton').connect('value-changed', Lang.bind (this, function(widget) {
+                this._settings.set_int('showdesktop-button-width', widget.get_value());
+            }));
+
+            dialog.connect('response', Lang.bind(this, function(dialog, id) {
+                if (id == 1) {
+                    // restore default settings
+                    this._settings.set_value('showdesktop-button-width', this._settings.get_default_value('showdesktop-button-width'));
+                    this._builder.get_object('show_showdesktop_width_spinbutton').set_value(this._settings.get_int('showdesktop-button-width'));
+                } else {
+                    // remove the settings box so it doesn't get destroyed;
+                    dialog.get_content_area().remove(box);
+                    dialog.destroy();
+                }
+                return;
+            }));
+
+            dialog.show_all();
+        }));
+
         this._settings.bind('show-appmenu',
                             this._builder.get_object('show_appmenu_switch'),
                             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -172,6 +172,11 @@
       <summary>Show desktop button</summary>
       <description>Show button on right side of bar that minimizes/restores all visible windows on current workspace</description>
     </key>
+    <key type="i" name="showdesktop-button-width">
+      <default>4</default>
+      <summary>Width of show Desktop button</summary>
+      <description>Customize the width of the show Desktop button</description>
+    </key>
     <key type="b" name="show-appmenu">
       <default>false</default>
       <summary>Show appMenu button</summary>


### PR DESCRIPTION
Hey Jason! a small improvement for people like me (and #305) having a 2 monitors setup with the "show desktop button" being on the edge between the 2 monitors. I know that this issue wasn't flagged as "help wanted", but it seemed like an easy fix that shouldn't break anything else. Thanks!