### PR TITLE
Add a polyfill for the findIndex method

### DIFF
--- a/taskbar.js
+++ b/taskbar.js
@@ -78,6 +78,27 @@ function extendDashItemContainer(dashItemContainer) {
  * - handle horizontal dash
  */
 
+//Polyfills
+if (!Array.prototype.findIndex) {
+    Array.prototype.findIndex = function(predicate) {
+        if (!this) {
+            throw new TypeError('findindex called on a null array');
+        }
+
+        if (typeof predicate !== 'function') {
+            throw new TypeError('predicate must be a function');
+        }
+
+        for (var i = 0, l = this.length; i < l; ++i) {
+            if (predicate(this[i])) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}
+
 var taskbarActor = new Lang.Class({
     Name: 'DashToPanel.TaskbarActor',
 
@@ -436,10 +457,10 @@ var taskbar = new Lang.Class({
 
     handleIsolatedWorkspaceSwitch: function() {
         if (this.isGroupApps) {
-            return this._queueRedisplay();
+            this._queueRedisplay();
+        } else {
+            this.resetAppIcons();
         }
-
-        this.resetAppIcons();
     },
 
     _connectWorkspaceSignals: function() {


### PR DESCRIPTION
Hey Jason! Seems like the older versions of gnome aren't supporting the array findIndex method. I checked in ubuntu gnome 16.04 (gnome-shell 3.18.5) and it is causing an issue with the ungrouping modification (as reported in #302). I added a simple polyfill to have it working again. Sorry about that, I should have tested on more distro/versions. Thanks!