### PR TITLE
Fix compatibility of the apps ungrouping with older gnome versions

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -604,36 +604,35 @@ var dtpPanel = new Lang.Class({
     _dtpUpdateSolidStyle: function() {
         if (this.actor.has_style_pseudo_class('overview') || !Main.sessionMode.hasWindows) {
             this._removeStyleClassName('solid');
-            return false;
+        } else {
+            /* Get all the windows in the active workspace that are in the
+            * primary monitor and visible */
+            let activeWorkspace = global.screen.get_active_workspace();
+            let windows = activeWorkspace.list_windows().filter(function(metaWindow) {
+                return metaWindow.is_on_primary_monitor() &&
+                    metaWindow.showing_on_its_workspace() &&
+                    metaWindow.get_window_type() != Meta.WindowType.DESKTOP;
+            });
+
+            /* Check if at least one window is near enough to the panel */
+            let [, panelTop] = this.actor.get_transformed_position();
+            let panelBottom = panelTop + this.actor.get_height();
+            let scale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+            let isNearEnough = windows.some(Lang.bind(this, function(metaWindow) {
+                if (this.hasOwnProperty('_dtpPosition') && this._dtpPosition === 'TOP') {
+                    let verticalPosition = metaWindow.get_frame_rect().y;
+                    return verticalPosition < panelBottom + 5 * scale;
+                } else {
+                    let verticalPosition = metaWindow.get_frame_rect().y + metaWindow.get_frame_rect().height;
+                    return verticalPosition > panelTop - 5 * scale;
+                }
+            }));
+
+            if (isNearEnough)
+                this._addStyleClassName('solid');
+            else
+                this._removeStyleClassName('solid');
         }
-
-        /* Get all the windows in the active workspace that are in the
-         * primary monitor and visible */
-        let activeWorkspace = global.screen.get_active_workspace();
-        let windows = activeWorkspace.list_windows().filter(function(metaWindow) {
-            return metaWindow.is_on_primary_monitor() &&
-                metaWindow.showing_on_its_workspace() &&
-                metaWindow.get_window_type() != Meta.WindowType.DESKTOP;
-        });
-
-        /* Check if at least one window is near enough to the panel */
-        let [, panelTop] = this.actor.get_transformed_position();
-        let panelBottom = panelTop + this.actor.get_height();
-        let scale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
-        let isNearEnough = windows.some(Lang.bind(this, function(metaWindow) {
-            if (this.hasOwnProperty('_dtpPosition') && this._dtpPosition === 'TOP') {
-                let verticalPosition = metaWindow.get_frame_rect().y;
-                return verticalPosition < panelBottom + 5 * scale;
-            } else {
-                let verticalPosition = metaWindow.get_frame_rect().y + metaWindow.get_frame_rect().height;
-                return verticalPosition > panelTop - 5 * scale;
-            }
-        }));
-
-        if (isNearEnough)
-            this._addStyleClassName('solid');
-        else
-            this._removeStyleClassName('solid');
     }
 });
 

--- a/taskbar.js
+++ b/taskbar.js
@@ -78,26 +78,19 @@ function extendDashItemContainer(dashItemContainer) {
  * - handle horizontal dash
  */
 
-//Polyfills
-if (!Array.prototype.findIndex) {
-    Array.prototype.findIndex = function(predicate) {
-        if (!this) {
-            throw new TypeError('findindex called on a null array');
-        }
-
-        if (typeof predicate !== 'function') {
-            throw new TypeError('predicate must be a function');
-        }
-
-        for (var i = 0, l = this.length; i < l; ++i) {
-            if (predicate(this[i])) {
-                return i;
-            }
-        }
-
-        return -1;
+function findIndex(array, predicate) {
+    if (Array.prototype.findIndex) {
+        return array.findIndex(predicate);
     }
-}
+
+    for (let i = 0, l = array.length; i < l; ++i) {
+        if (predicate(array[i])) {
+            return i;
+        }
+    }
+
+    return -1;
+};
 
 var taskbarActor = new Lang.Class({
     Name: 'DashToPanel.TaskbarActor',
@@ -793,8 +786,8 @@ var taskbar = new Lang.Class({
         //remove the appIcons which are not in the expected apps list
         for (let i = currentAppIcons.length - 1; i > -1; --i) {
             let appIcon = currentAppIcons[i].child._delegate;
-            let appIndex = expectedAppInfos.findIndex(appInfo => appInfo.app == appIcon.app &&
-                                                                 appInfo.isLauncher == appIcon.isLauncher);
+            let appIndex = findIndex(expectedAppInfos, appInfo => appInfo.app == appIcon.app &&
+                                                                  appInfo.isLauncher == appIcon.isLauncher);
 
             if (appIndex < 0 || 
                 (appIcon.window && (this.isGroupApps || expectedAppInfos[appIndex].windows.indexOf(appIcon.window) < 0)) ||
@@ -814,8 +807,8 @@ var taskbar = new Lang.Class({
                                  
             for (let j = 0, ll = neededAppIcons.length; j < ll; ++j) {
                 //check if the icon already exists
-                let matchingAppIconIndex = currentAppIcons.findIndex(appIcon => appIcon.child._delegate.app == neededAppIcons[j].app && 
-                                                                                appIcon.child._delegate.window == neededAppIcons[j].window);
+                let matchingAppIconIndex = findIndex(currentAppIcons, appIcon => appIcon.child._delegate.app == neededAppIcons[j].app && 
+                                                                                 appIcon.child._delegate.window == neededAppIcons[j].window);
 
                 if (matchingAppIconIndex > 0 && matchingAppIconIndex != currentPosition) {
                     //moved icon, reposition it


### PR DESCRIPTION
Hey Jason! Another day, another fix concerning the older gnome-shell versions (Arc-Menu search mentioned in #302)... I could reproduce it on gnome 3.18.5. Don't ask me to explain what was happening with this :) but it should be good now, I think.

Also, the modification in panel.js is another fix for a "doesn't always return a value" log message. 

Thanks!