### PR TITLE
Fix for gjs 1.50.4 warnings

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -289,6 +289,7 @@ var taskbarAppIcon = new Lang.Class({
 
     _onDestroy: function() {
         this.parent();
+        this._destroyed = true;
 
         // Disconect global signals
         // stateChangedId is already handled by parent)
@@ -568,10 +569,12 @@ var taskbarAppIcon = new Lang.Class({
             isFocused = (tracker.focus_app == this.app);
 
             Mainloop.timeout_add(0, () => {
-                if(isFocused) 
-                    this.actor.add_style_class_name('focused');
-                else
-                    this.actor.remove_style_class_name('focused');
+                if (!this._destroyed) {
+                    if(isFocused) 
+                        this.actor.add_style_class_name('focused');
+                    else
+                        this.actor.remove_style_class_name('focused');
+                }
             });
             
             if(focusedIsWide) {

--- a/taskbar.js
+++ b/taskbar.js
@@ -240,9 +240,6 @@ var taskbar = new Lang.Class({
             y_align: St.Align.START, x_align:rtl?St.Align.END:St.Align.START
         });
 
-        Main.panel.actor.connect('notify::height', Lang.bind(this, this._queueRedisplay));
-        Main.panel.actor.connect('notify::width', Lang.bind(this, this._queueRedisplay));
-
         // Update minimization animation target position on allocation of the
         // container and on scrollview change.
         this._box.connect('notify::allocation', Lang.bind(this, this._updateAppIconsGeometry));
@@ -256,6 +253,16 @@ var taskbar = new Lang.Class({
         this._appSystem = Shell.AppSystem.get_default();
 
         this._signalsHandler.add(
+            [
+                Main.panel.actor,
+                'notify::height',
+                () => this._queueRedisplay()
+            ],
+            [
+                Main.panel.actor,
+                'notify::width',
+                () => this._queueRedisplay()
+            ],
             [
                 this._appSystem,
                 'installed-changed',
@@ -313,6 +320,7 @@ var taskbar = new Lang.Class({
         this._signalsHandler.destroy();
         this._signalsHandler = 0;
 
+        this._container.destroy();
         this._disconnectWorkspaceSignals();
     },
 

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -750,17 +750,19 @@ var thumbnailPreview = new Lang.Class({
     },
 
     animateOutAndDestroy: function() {
-        this.animatingOut = true;
-        this._hideCloseButton();
-        Tweener.addTween(this.actor,
-                         { width: 0,
-                           opacity: 0,
-                           time: Taskbar.DASH_ANIMATION_TIME,
-                           transition: 'easeOutQuad',
-                           onComplete: Lang.bind(this, function() {
-                               this.destroy();
-                           })
-                         });
+        if (!this.animatingOut) {
+            this.animatingOut = true;
+            this._hideCloseButton();
+            Tweener.addTween(this.actor,
+                             {  width: 0,
+                                opacity: 0,
+                                time: Taskbar.DASH_ANIMATION_TIME,
+                                transition: 'easeOutQuad',
+                                onComplete: Lang.bind(this, function() {
+                                    this.destroy();
+                                })
+                             });
+        }
     },
 
     activate: function() {
@@ -1002,7 +1004,9 @@ var thumbnailPreviewList = new Lang.Class({
         let windows = this.window ? [this.window] : 
                       AppIcons.getInterestingWindows(this.app, this._dtpSettings).sort(this.sortWindowsCompareFunction);
         let children = this.box.get_children().filter(function(actor) {
-                return actor._delegate.window && actor._delegate.preview;
+                return actor._delegate.window && 
+                       actor._delegate.preview && 
+                       !actor._delegate.animatingOut;
             });
         // Apps currently in the taskbar
         let oldWin = children.map(function(actor) {

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -671,11 +671,6 @@ var thumbnailPreview = new Lang.Class({
                                              height: height * this.scale });
             this._resizeId = mutterWindow.meta_window.connect('size-changed',
                                             Lang.bind(this, this._queueResize));
-            this._destroyId = mutterWindow.connect('destroy', Lang.bind(this, function() {
-                                                   thumbnail.destroy();
-                                                   this._destroyId = 0;
-                                                   this.animateOutAndDestroy();
-                                                  }));
         }
 
         return thumbnail;

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -212,6 +212,9 @@ var thumbnailPreviewMenu = new Lang.Class({
     },
 
     destroy: function () {
+        this.cancelClose();
+        this.cancelOpen();
+        
         if (this._mappedId)
             this._source.actor.disconnect(this._mappedId);
 


### PR DESCRIPTION
Hey Jason! I investigated the warnings received after upgrading to gjs 1.50.4 (#338) and found out that the appicon's ondestroy function isn't called when the extension is disabled. This commit fixes that and also removes a timer that could end after the windowpreviews are destroyed (also reported as a warning by the latest gjs).

Now, on my end, the only warnings I get from gjs is from tweener.js and this one is [out of our hands](https://bugs.launchpad.net/ubuntu/+source/gnome-shell/+bug/1747566)

Sorry I couldn't fix that in time for v12 :(
Thanks