### PR TITLE
Fix touchscreen behaviour for taskbarAppIcon (#223)

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -106,17 +106,22 @@ var taskbarAppIcon = new Lang.Class({
 		// Fix touchscreen issues before the listener is added by the parent constructor.
         this._onTouchEvent = function(actor, event) {
             if (event.type() == Clutter.EventType.TOUCH_BEGIN) {
-                // Activate/launch the application, on touch start because touch end doesn't work sometimes.
-                this.activate(1);
-                
                 // Open the popup menu on long press.
-            	this._setPopupTimeout();
-            } else if (this._menuTimeoutId != 0 && (event.type() == Clutter.EventType.TOUCH_END || event.type() == Clutter.EventType.TOUCH_CANCEL)) {
-            	this._removeMenuTimeout();
+                this._setPopupTimeout();
+            } else if (this._menuTimeoutId != 0 && (event.type() == Clutter.EventType.TOUCH_END || event.type() == Clutter.EventType.TOUCH_CANCEL)) {    
+                // Activate/launch the application.
+                this.activate(1);
+                this._removeMenuTimeout();
             }
             // Disable dragging via touch screen as it's buggy as hell. Not perfect for tablet users, but the alternative is way worse.
             // Also, EVENT_PROPAGATE launches applications twice with this solution, so this.activate(1) above must only be called if there's already a window.
             return Clutter.EVENT_STOP;
+        };
+        // Hack for missing TOUCH_END event.
+        this._onLeaveEvent = function(actor, event) {
+            this.actor.fake_release();
+            if (this._menuTimeoutId != 0) this.activate(1); // Activate/launch the application if TOUCH_END didn't fire.
+            this._removeMenuTimeout();
         };
 
         this.parent(appInfo.app, iconParams, onActivateOverride);

--- a/appIcons.js
+++ b/appIcons.js
@@ -103,6 +103,22 @@ var taskbarAppIcon = new Lang.Class({
         this.window = appInfo.window;
         this.isLauncher = appInfo.isLauncher;
 
+		// Fix touchscreen issues before the listener is added by the parent constructor.
+        this._onTouchEvent = function(actor, event) {
+            if (event.type() == Clutter.EventType.TOUCH_BEGIN) {
+                // Activate/launch the application, on touch start because touch end doesn't work sometimes.
+                this.activate(1);
+                
+                // Open the popup menu on long press.
+            	this._setPopupTimeout();
+            } else if (this._menuTimeoutId != 0 && (event.type() == Clutter.EventType.TOUCH_END || event.type() == Clutter.EventType.TOUCH_CANCEL)) {
+            	this._removeMenuTimeout();
+            }
+            // Disable dragging via touch screen as it's buggy as hell. Not perfect for tablet users, but the alternative is way worse.
+            // Also, EVENT_PROPAGATE launches applications twice with this solution, so this.activate(1) above must only be called if there's already a window.
+            return Clutter.EVENT_STOP;
+        };
+
         this.parent(appInfo.app, iconParams, onActivateOverride);
 
         this._dot.set_width(0);


### PR DESCRIPTION
Behaviour that might be unexpected:
- long-pressing a background application opens the popup menu, but still activates/starts the application. Only activating the application on TOUCH_END/TOUCH_CANCEL turned out to work only sometimes on my system, I'll do some further tests on that.
- dragging via touchscreen is completely disabled for now, as it gets confused with the mouse, bugs around and in the end breaks everything (as said in the issue, up to a frozen system).