### PR TITLE
Ignore the desktop when the "Show icons" option is enabled

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -288,8 +288,11 @@ var Intellihide = new Lang.Class({
     },
 
     _checkIfHandledWindowType(metaWindow) {
+        let metaWindowType = metaWindow.get_window_type();
+
         //https://www.roojs.org/seed/gir-1.2-gtk-3.0/seed/Meta.WindowType.html
-        return metaWindow.get_window_type() <= Meta.WindowType.SPLASHSCREEN;
+        return metaWindowType <= Meta.WindowType.SPLASHSCREEN && 
+               metaWindowType != Meta.WindowType.DESKTOP;
     },
 
     _queueUpdatePanelPosition: function(fromRevealMechanism) {


### PR DESCRIPTION
Hey Jason, this is a fix for issue #356, I was wondering when this "desktop" windowtype would show up. Looks like the desktop icons must be shown :)  