### PR TITLE
Fix syntax error reported by older gnome-shell versions

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -392,8 +392,6 @@ var Intellihide = new Lang.Class({
             Tweener.removeTweens(this._panelBox);
         }
 
-        this._animationDestination = destination;
-
         if (immediate) {
             this._panelBox.translation_y = destination;
             this._invokeIfExists(onComplete);
@@ -410,9 +408,10 @@ var Intellihide = new Lang.Class({
                     this._timeoutsHandler.add([T3, POST_ANIMATE_MS, () => this._queueUpdatePanelPosition()]);
                 }
             });
-
-            this._hoveredOut = false;
         }
+
+        this._animationDestination = destination;
+        this._hoveredOut = false;
     },
 
     _invokeIfExists: function(func) {

--- a/intellihide.js
+++ b/intellihide.js
@@ -175,7 +175,7 @@ var Intellihide = new Lang.Class({
                 this._dtpSettings,
                 'changed::intellihide-behaviour',
                 () => this._queueUpdatePanelPosition()
-            ],
+            ]
         );
     },
 
@@ -379,7 +379,7 @@ var Intellihide = new Lang.Class({
         this._animatePanel(this._panelBox.height * (this._panelAtTop ? -1 : 1), immediate);
     },
 
-    _animatePanel: function(destination,immediate, onComplete) {
+    _animatePanel: function(destination, immediate, onComplete) {
         let animating = Tweener.isTweening(this._panelBox);
 
         if ((animating && destination === this._animationDestination) || 
@@ -410,6 +410,8 @@ var Intellihide = new Lang.Class({
                     this._timeoutsHandler.add([T3, POST_ANIMATE_MS, () => this._queueUpdatePanelPosition()]);
                 }
             });
+
+            this._hoveredOut = false;
         }
     },
 

--- a/intellihide.js
+++ b/intellihide.js
@@ -267,7 +267,7 @@ var Intellihide = new Lang.Class({
         }
     },
 
-    _disconnectFocusedWindow() {
+    _disconnectFocusedWindow: function() {
         if (this._focusedWindowInfo) {
             this._focusedWindowInfo.window.disconnect(this._focusedWindowInfo.id);
             this._focusedWindowInfo = null;
@@ -280,14 +280,14 @@ var Intellihide = new Lang.Class({
                      .filter(mw => this._checkIfHandledWindow(mw));
     },
 
-    _checkIfHandledWindow(metaWindow) {
+    _checkIfHandledWindow: function(metaWindow) {
         return metaWindow && !metaWindow.minimized &&
                metaWindow.get_workspace().index() == global.screen.get_active_workspace_index() &&
                metaWindow.get_monitor() == Main.layoutManager.primaryIndex &&
                this._checkIfHandledWindowType(metaWindow);
     },
 
-    _checkIfHandledWindowType(metaWindow) {
+    _checkIfHandledWindowType: function(metaWindow) {
         let metaWindowType = metaWindow.get_window_type();
 
         //https://www.roojs.org/seed/gir-1.2-gtk-3.0/seed/Meta.WindowType.html
@@ -360,7 +360,7 @@ var Intellihide = new Lang.Class({
         return windowBottom >= panelTop;
     },
 
-    _checkIfGrab() {
+    _checkIfGrab: function() {
         if (GrabHelper._grabHelperStack.some(gh => this._panelBox.contains(gh._owner))) {
             //there currently is a grab on a child of the panel, check again soon to catch its release
             this._timeoutsHandler.add([T1, CHECK_GRAB_MS, () => this._queueUpdatePanelPosition()]);


### PR DESCRIPTION
Hey Jason, small fix (probably) for the syntax error discovered in #357. I also reseted an indicator controlling the panel hiding delay, so that it only applies when the user hovers out of the panel after revealing it. Thanks!