### PR TITLE
Fix the intellihide animations when entering/leaving the overview

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -22,6 +22,7 @@ const Shell = imports.gi.Shell;
 const GrabHelper = imports.ui.grabHelper;
 const Layout = imports.ui.layout;
 const Main = imports.ui.main;
+const OverviewControls = imports.ui.overviewControls;
 const PointerWatcher = imports.ui.pointerWatcher;
 const Tweener = imports.ui.tweener;
 
@@ -154,7 +155,7 @@ var Intellihide = new Lang.Class({
                 Main.overview,
                 [
                     'showing',
-                    'hidden'
+                    'hiding'
                 ],
                 () => this._queueUpdatePanelPosition()
             ]
@@ -330,7 +331,7 @@ var Intellihide = new Lang.Class({
             return !this._dragging;
         }
 
-        if (Main.overview.visible || this._checkIfGrab() || this._panelBox.get_hover()) {
+        if (Main.overview.visibleTarget || this._checkIfGrab() || this._panelBox.get_hover()) {
             return true;
         }
 
@@ -405,7 +406,10 @@ var Intellihide = new Lang.Class({
             } else {
                 Tweener.addTween(this._panelBox, {
                     translation_y: destination,
-                    time: this._dtpSettings.get_int('intellihide-animation-time') * 0.001,
+                    //when entering/leaving the overview, use its animation time instead of the one from the settings
+                    time: Main.overview.visible ? 
+                          OverviewControls.SIDE_CONTROLS_ANIMATION_TIME :
+                          this._dtpSettings.get_int('intellihide-animation-time') * 0.001,
                     //only delay the animation when hiding the panel after the user hovered out
                     delay: destination != 0 && this._hoveredOut ? this._dtpSettings.get_int('intellihide-close-delay') * 0.001 : 0,
                     transition: 'easeOutQuad',

--- a/intellihide.js
+++ b/intellihide.js
@@ -153,7 +153,7 @@ var Intellihide = new Lang.Class({
             [
                 Main.overview,
                 [
-                    'shown',
+                    'showing',
                     'hidden'
                 ],
                 () => this._queueUpdatePanelPosition()
@@ -203,7 +203,7 @@ var Intellihide = new Lang.Class({
             this._pressureBarrier = new Layout.PressureBarrier(
                 this._dtpSettings.get_int('intellihide-pressure-threshold'), 
                 this._dtpSettings.get_int('intellihide-pressure-time'), 
-                Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW
+                Shell.ActionMode.NORMAL
             );
             this._pressureBarrier.addBarrier(this._createBarrier());
             this._signalsHandler.add([this._pressureBarrier, 'trigger', () => this._queueUpdatePanelPosition(true)]);
@@ -246,7 +246,7 @@ var Intellihide = new Lang.Class({
     },
 
     _checkMousePointer: function(x, y) {
-        if (!this._panelBox.hover &&
+        if (!this._panelBox.hover && !Main.overview.visible &&
             ((this._panelAtTop && y <= this._primaryMonitor.y + 1) || 
              (!this._panelAtTop && y >= this._primaryMonitor.y + this._primaryMonitor.height - 1)) &&
             (x > this._primaryMonitor.x && x < this._primaryMonitor.x + this._primaryMonitor.width)) {


### PR DESCRIPTION
Hey Jason, here are more fixes for the overview, as discussed in #360. With this, the mouse at the edge of the screen has no effect while in overview and the panel now uses the same animation timing as the workspaces bar (you were right, looks much better :) Thanks!  