### PR TITLE
Add missing reference to GLib

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -26,6 +26,7 @@ const Overview = Me.imports.overview;
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
 const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 const Shell = imports.gi.Shell;
 const WindowManager = imports.ui.windowManager;

--- a/intellihide.js
+++ b/intellihide.js
@@ -305,8 +305,9 @@ var Intellihide = new Lang.Class({
     },
 
     _queueUpdatePanelPosition: function(fromRevealMechanism) {
-        if (!fromRevealMechanism && this._timeoutsHandler.getId(T2)) {
-            //limit the number of updates, but remember to update again when the limit timeout is reached
+        if (!fromRevealMechanism && this._timeoutsHandler.getId(T2) && !Main.overview.visible) {
+            //unless this is a mouse interaction or entering/leaving the overview, limit the number
+            //of updates, but remember to update again when the limit timeout is reached
             this._pendingUpdate = true;
         } else {
             this._checkIfShouldBeVisible(fromRevealMechanism) ? this._revealPanel() : this._hidePanel();


### PR DESCRIPTION
Hey Jason, I'm looking at Ubuntu 18.04 and I noticed an error when disabling the dock (disabling it causes a lot of errors, but on the ubuntu-dock side of things). I also ignored the intellihide update delay when exiting the overview. Thanks.