### PR TITLE
Ignore window resizing while in fullscreen mode

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -325,7 +325,7 @@ var Intellihide = new Lang.Class({
     _checkIfShouldBeVisible: function(fromRevealMechanism) {
         if (fromRevealMechanism) {
             //the user is trying to reveal the panel
-            if (this._primaryMonitor.inFullscreen) {
+            if (this._primaryMonitor.inFullscreen && !this._dragging) {
                 return this._dtpSettings.get_boolean('intellihide-show-in-fullscreen');
             }
             


### PR DESCRIPTION
Hey Jason, I just noticed a small issue with the intellihide. When you are in "hide from focused window" mode and there is a fullscreen window in the background, if you resize a foreground window over the panel (by dragging one of its bottom corners), the panel hides and then reveal itself again. This PR fixes that. Thanks!