### PR TITLE
Ensure the adjustment of the dynamic transparency when exiting the ov…

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -184,6 +184,11 @@ var Intellihide = new Lang.Class({
                 this._dtpSettings,
                 'changed::intellihide-behaviour',
                 () => this._queueUpdatePanelPosition()
+            ],
+            [
+                Main.overview,
+                'hidden',
+                () => this._adjustDynamicTransparency()
             ]
         );
     },
@@ -259,13 +264,13 @@ var Intellihide = new Lang.Class({
         this._disconnectFocusedWindow();
 
         let focusedWindow = global.display.focus_window;
-
+        
         if (focusedWindow) {
             let window = (focusedWindow.is_attached_dialog() ? 
                           focusedWindow.get_transient_for() : 
                           focusedWindow).get_compositor_private();
             let metaWindow = window.get_meta_window();
-
+        
             if (this._checkIfHandledWindowType(metaWindow)) {
                 this._focusedWindowInfo = {
                     window: window,
@@ -381,8 +386,12 @@ var Intellihide = new Lang.Class({
         return false;
     },
 
+    _adjustDynamicTransparency: function() {
+        this._invokeIfExists(this._dtpPanel.panel._updateSolidStyle);
+    },
+
     _revealPanel: function(immediate) {
-        this._animatePanel(0, immediate, () => this._invokeIfExists(this._dtpPanel.panel._updateSolidStyle));
+        this._animatePanel(0, immediate, () => this._adjustDynamicTransparency());
     },
 
     _hidePanel: function(immediate) {

--- a/intellihide.js
+++ b/intellihide.js
@@ -264,13 +264,13 @@ var Intellihide = new Lang.Class({
         this._disconnectFocusedWindow();
 
         let focusedWindow = global.display.focus_window;
-        
+
         if (focusedWindow) {
             let window = (focusedWindow.is_attached_dialog() ? 
                           focusedWindow.get_transient_for() : 
                           focusedWindow).get_compositor_private();
             let metaWindow = window.get_meta_window();
-        
+
             if (this._checkIfHandledWindowType(metaWindow)) {
                 this._focusedWindowInfo = {
                     window: window,
@@ -391,7 +391,7 @@ var Intellihide = new Lang.Class({
     },
 
     _revealPanel: function(immediate) {
-        this._animatePanel(0, immediate, () => this._adjustDynamicTransparency());
+        this._animatePanel(0, immediate, this._adjustDynamicTransparency);
     },
 
     _hidePanel: function(immediate) {

--- a/intellihide.js
+++ b/intellihide.js
@@ -184,11 +184,6 @@ var Intellihide = new Lang.Class({
                 this._dtpSettings,
                 'changed::intellihide-behaviour',
                 () => this._queueUpdatePanelPosition()
-            ],
-            [
-                Main.overview,
-                'hidden',
-                () => this._adjustDynamicTransparency()
             ]
         );
     },

--- a/panel.js
+++ b/panel.js
@@ -198,6 +198,11 @@ var dtpPanel = new Lang.Class({
                 })
             ],
             [
+                Main.overview,
+                'hidden',
+                () => this.panel._updateSolidStyle ? this.panel._updateSolidStyle() : null
+            ],
+            [
                 this.panel._rightBox,
                 'actor-added',
                 Lang.bind(this, function() {


### PR DESCRIPTION
Hey Jason, here is another small fix to address #369. This ensure that the dynamic transparency is correctly applied when the window focus changes in overview while being in the "only hide from the focused window" mode. Thanks